### PR TITLE
unix,win: add uv_sleep()

### DIFF
--- a/docs/src/misc.rst
+++ b/docs/src/misc.rst
@@ -694,3 +694,9 @@ API
         are not used and can be set to `NULL`.
 
     .. versionadded:: 1.33.0
+
+.. c:function:: void uv_sleep(unsigned int msec)
+
+    Causes the calling thread to sleep for `msec` milliseconds.
+
+    .. versionadded:: 1.34.0

--- a/include/uv.h
+++ b/include/uv.h
@@ -1641,6 +1641,7 @@ UV_EXTERN uint64_t uv_get_total_memory(void);
 UV_EXTERN uint64_t uv_get_constrained_memory(void);
 
 UV_EXTERN uint64_t uv_hrtime(void);
+UV_EXTERN void uv_sleep(unsigned int msec);
 
 UV_EXTERN void uv_disable_stdio_inheritance(void);
 

--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -1555,3 +1555,15 @@ int uv_gettimeofday(uv_timeval64_t* tv) {
   tv->tv_usec = (int32_t) time.tv_usec;
   return 0;
 }
+
+void uv_sleep(unsigned int msec) {
+  unsigned int sec;
+  unsigned int usec;
+
+  sec = msec / 1000;
+  usec = (msec % 1000) * 1000;
+  if (sec > 0)
+    sleep(sec);
+  if (usec > 0)
+    usleep(usec);
+}

--- a/src/win/util.c
+++ b/src/win/util.c
@@ -1873,3 +1873,7 @@ int uv__random_rtlgenrandom(void* buf, size_t buflen) {
 
   return 0;
 }
+
+void uv_sleep(unsigned int msec) {
+  Sleep(msec);
+}

--- a/test/runner-unix.c
+++ b/test/runner-unix.c
@@ -448,17 +448,3 @@ void rewind_cursor(void) {
   fprintf(stderr, "\033[2K\r");
 #endif
 }
-
-
-/* Pause the calling thread for a number of milliseconds. */
-void uv_sleep(int msec) {
-  int sec;
-  int usec;
-
-  sec = msec / 1000;
-  usec = (msec % 1000) * 1000;
-  if (sec > 0)
-    sleep(sec);
-  if (usec > 0)
-    usleep(usec);
-}

--- a/test/runner-win.c
+++ b/test/runner-win.c
@@ -355,9 +355,3 @@ void rewind_cursor() {
     fprintf(stderr, "\n");
   }
 }
-
-
-/* Pause the calling thread for a number of milliseconds. */
-void uv_sleep(int msec) {
-  Sleep(msec);
-}

--- a/test/task.h
+++ b/test/task.h
@@ -131,9 +131,6 @@ typedef enum {
   int run_helper_##name(void);                                                \
   int run_helper_##name(void)
 
-/* Pause the calling thread for a number of milliseconds. */
-void uv_sleep(int msec);
-
 /* Format big numbers nicely. WARNING: leaks memory. */
 const char* fmt(double d);
 


### PR DESCRIPTION
This commit exposes the uv_sleep() function that previously
only existed in the test runner.

PR-URL: https://github.com/libuv/libuv/pull/2548
Reviewed-By: Anna Henningsen <anna@addaleax.net>
Reviewed-By: Richard Lau <riclau@uk.ibm.com>