### PR TITLE
test: fix env-vars flakiness

### DIFF
--- a/test/test-env-vars.c
+++ b/test/test-env-vars.c
@@ -102,6 +102,12 @@ TEST_IMPL(env_vars) {
   ASSERT(r == 0);
   r = uv_os_setenv(name2, "");
   ASSERT(r == 0);
+#ifdef _WIN32
+  /* Create a special environment variable on Windows in case there are no
+     naturally occurring ones. */
+  r = uv_os_setenv("=Z:", "\\");
+  ASSERT(r == 0);
+#endif
 
   r = uv_os_environ(&envitems, &envcount);
   ASSERT(r == 0);


### PR DESCRIPTION
It has been observed that running the tests via shell script
can cause special environment variables to be missing. This
commit ensures that a special Windows environment variable is set.

Fixes: https://github.com/libuv/libuv/issues/2622
PR-URL: https://github.com/libuv/libuv/pull/2624
Reviewed-By: Jameson Nash <vtjnash@gmail.com>
Reviewed-By: Richard Lau <riclau@uk.ibm.com>