### PR TITLE
test: avoid truncating output lines

### DIFF
--- a/test/runner-unix.c
+++ b/test/runner-unix.c
@@ -371,8 +371,8 @@ int process_copy_output(process_info_t* p, FILE* stream) {
   }
 
   /* TODO: what if the line is longer than buf */
-  while (fgets(buf, sizeof(buf), p->stdout_file) != NULL)
-    print_lines(buf, strlen(buf), stream);
+  while ((r = fread(buf, 1, sizeof(buf), p->stdout_file)) != 0)
+    print_lines(buf, r, stream);
 
   if (ferror(p->stdout_file)) {
     perror("read");
@@ -398,7 +398,8 @@ int process_read_last_line(process_info_t *p,
   buffer[0] = '\0';
 
   while (fgets(buffer, buffer_len, p->stdout_file) != NULL) {
-    for (ptr = buffer; *ptr && *ptr != '\r' && *ptr != '\n'; ptr++);
+    for (ptr = buffer; *ptr && *ptr != '\r' && *ptr != '\n'; ptr++)
+      ;
     *ptr = '\0';
   }
 

--- a/test/runner-win.c
+++ b/test/runner-win.c
@@ -222,28 +222,19 @@ long int process_output_size(process_info_t *p) {
 int process_copy_output(process_info_t* p, FILE* stream) {
   char buf[1024];
   int fd, r;
-  FILE* f;
 
   fd = _open_osfhandle((intptr_t)p->stdio_out, _O_RDONLY | _O_TEXT);
   if (fd == -1)
     return -1;
-  f = _fdopen(fd, "rt");
-  if (f == NULL) {
-    _close(fd);
-    return -1;
-  }
 
-  r = fseek(f, 0, SEEK_SET);
+  r = _lseek(fd, 0, SEEK_SET);
   if (r < 0)
     return -1;
 
-  while (fgets(buf, sizeof(buf), f) != NULL)
-    print_lines(buf, strlen(buf), stream);
+  while ((r = _read(fd, buf, sizeof(buf))) != 0)
+    print_lines(buf, r, stream);
 
-  if (ferror(f))
-    return -1;
-
-  fclose(f);
+  _close(fd);
   return 0;
 }
 

--- a/test/runner.c
+++ b/test/runner.c
@@ -419,13 +419,18 @@ void print_lines(const char* buffer, size_t size, FILE* stream) {
 
   start = buffer;
   while ((end = memchr(start, '\n', &buffer[size] - start))) {
-    fprintf(stream, "# %.*s\n", (int) (end - start), start);
+    fputs("# ", stream);
+    fwrite(start, 1, (int)(end - start), stream);
+    fputs("\n", stream);
     fflush(stream);
     start = end + 1;
   }
 
-  if (start < &buffer[size]) {
-    fprintf(stream, "# %s\n", start);
+  end = &buffer[size];
+  if (start < end) {
+    fputs("# ", stream);
+    fwrite(start, 1, (int)(end - start), stream);
+    fputs("\n", stream);
     fflush(stream);
   }
 }


### PR DESCRIPTION
If the output data contained a null byte (for example, because it was
really utf16), we'd truncate the output there. This commonly would
manifest as the output on the CI bot being:

> not ok 308 - threadpool_cancel_random
> # exit code 3
> # Output from process :
> # A

Now we'll attempt to print out the whole error message as text (albeit
with the wrong encoding, but the ascii content should still nearly
always be readable).

PR-URL: https://github.com/libuv/libuv/pull/2611
Reviewed-By: Colin Ihrig <cjihrig@gmail.com>