### PR TITLE
test: handle EINTR, fix EOF check in poll test

### DIFF
--- a/test/test-poll.c
+++ b/test/test-poll.c
@@ -222,7 +222,10 @@ static void connection_poll_cb(uv_poll_t* handle, int status, int events) {
       case 1: {
         /* Read a couple of bytes. */
         static char buffer[74];
-        r = recv(context->sock, buffer, sizeof buffer, 0);
+
+        do
+          r = recv(context->sock, buffer, sizeof buffer, 0);
+        while (r == -1 && errno == EINTR);
         ASSERT(r >= 0);
 
         if (r > 0) {
@@ -240,12 +243,16 @@ static void connection_poll_cb(uv_poll_t* handle, int status, int events) {
       case 3: {
         /* Read until EAGAIN. */
         static char buffer[931];
-        r = recv(context->sock, buffer, sizeof buffer, 0);
-        ASSERT(r >= 0);
 
-        while (r > 0) {
+        for (;;) {
+          do
+            r = recv(context->sock, buffer, sizeof buffer, 0);
+          while (r == -1 && errno == EINTR);
+
+          if (r <= 0)
+            break;
+
           context->read += r;
-          r = recv(context->sock, buffer, sizeof buffer, 0);
         }
 
         if (r == 0) {
@@ -301,7 +308,9 @@ static void connection_poll_cb(uv_poll_t* handle, int status, int events) {
           int send_bytes = MIN(TRANSFER_BYTES - context->sent, sizeof buffer);
           ASSERT(send_bytes > 0);
 
-          r = send(context->sock, buffer, send_bytes, 0);
+          do
+            r = send(context->sock, buffer, send_bytes, 0);
+          while (r == -1 && errno == EINTR);
 
           if (r < 0) {
             ASSERT(got_eagain());
@@ -323,7 +332,9 @@ static void connection_poll_cb(uv_poll_t* handle, int status, int events) {
           int send_bytes = MIN(TRANSFER_BYTES - context->sent, sizeof buffer);
           ASSERT(send_bytes > 0);
 
-          r = send(context->sock, buffer, send_bytes, 0);
+          do
+            r = send(context->sock, buffer, send_bytes, 0);
+          while (r == -1 && errno == EINTR);
 
           if (r < 0) {
             ASSERT(got_eagain());
@@ -339,12 +350,18 @@ static void connection_poll_cb(uv_poll_t* handle, int status, int events) {
             send_bytes = MIN(TRANSFER_BYTES - context->sent, sizeof buffer);
             ASSERT(send_bytes > 0);
 
-            r = send(context->sock, buffer, send_bytes, 0);
+            do
+              r = send(context->sock, buffer, send_bytes, 0);
+            while (r == -1 && errno == EINTR);
+            ASSERT(r != 0);
 
-            if (r <= 0) break;
+            if (r < 0) {
+              ASSERT(got_eagain());
+              break;
+            }
+
             context->sent += r;
           }
-          ASSERT(r > 0 || got_eagain());
           break;
         }
 


### PR DESCRIPTION
The test had two bugs:

1. It didn't handle EINTR when calling send() and recv().

2. It checked `errno` on EOF but that's only set when the return value
   is less than zero.

PR-URL: https://github.com/libuv/libuv/pull/2713
Reviewed-By: Jameson Nash <vtjnash@gmail.com>
Reviewed-By: Richard Lau <riclau@uk.ibm.com>
Reviewed-By: Santiago Gimeno <santiago.gimeno@gmail.com>