### PR TITLE
unix: use socklen_t instead of size_t

### DIFF
--- a/src/unix/udp.c
+++ b/src/unix/udp.c
@@ -1087,7 +1087,7 @@ static int uv__setsockopt(uv_udp_t* handle,
                          int option4,
                          int option6,
                          const void* val,
-                         size_t size) {
+                         socklen_t size) {
   int r;
 
   if (handle->flags & UV_HANDLE_IPV6)


### PR DESCRIPTION
It has been reported that it generates (otherwise harmless)
`-Wshorten-64-to-32` compiler warnings when building for iOS.

Fixes: https://github.com/libuv/libuv/issues/2714
PR-URL: https://github.com/libuv/libuv/pull/2716
Reviewed-By: Colin Ihrig <cjihrig@gmail.com>
Reviewed-By: Saúl Ibarra Corretgé <s@saghul.net>